### PR TITLE
Fix server 500 error when trace has no issues

### DIFF
--- a/api/src/routes/issues.ts
+++ b/api/src/routes/issues.ts
@@ -32,6 +32,11 @@ app.get(
       }
     }
 
+    // If there are no matchingIssueId's we can return early
+    if (matchingIssueIds.length === 0) {
+      return ctx.json([]);
+    }
+
     const relevantIssues = z
       .array(schema.githubIssueSchema)
       .default([])


### PR DESCRIPTION
`inArray` function used to query the db doesn't like it when it gets an empty array