### PR TITLE
Embed Studio artifacts into fpx cli

### DIFF
--- a/fpx/Cargo.toml
+++ b/fpx/Cargo.toml
@@ -6,6 +6,9 @@ authors = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }
 
+[features]
+embed-studio = [] # When enabled it will embed Studio from frontend/dist
+
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { version = "0.1" }

--- a/fpx/src/api.rs
+++ b/fpx/src/api.rs
@@ -3,6 +3,7 @@ use crate::events::ServerEvents;
 use crate::inspector::InspectorService;
 use axum::extract::FromRef;
 use axum::response::Html;
+use axum::response::IntoResponse;
 use axum::routing::{any, get};
 use url::Url;
 
@@ -67,6 +68,10 @@ pub async fn create_api(
         .route("/api/inspect/:id", any(handlers::inspect_request_handler))
         .route("/api/v1/logs", get(handlers::logs_handler))
         .route("/api/ws", get(ws::ws_handler))
-        .route("/", get(|| async { Html("Hello, world!") }))
+        .fallback(default_handler)
         .with_state(api_state)
+}
+
+pub async fn default_handler() -> impl IntoResponse {
+    "Hello from the embedded UI "
 }

--- a/fpx/src/api/studio.rs
+++ b/fpx/src/api/studio.rs
@@ -1,0 +1,63 @@
+use axum::extract::Request;
+use axum::response::{IntoResponse, Response};
+use http::StatusCode;
+use include_dir::{include_dir, Dir, DirEntry};
+
+static STUDIO_DIST: Dir<'_> = include_dir!("$CARGO_MANIFEST_DIR/../frontend/dist");
+
+pub async fn default_handler(req: Request) -> Response {
+    // check if it is a file, if so return the file
+    // if it is a directory, return the index.html file
+    // otherwise _always_ fallback index.html
+
+    let path = req.uri().path().trim_start_matches('/');
+
+    if let Some(entry) = STUDIO_DIST.get_entry(path) {
+        match entry {
+            DirEntry::Dir(dir_entry) => {
+                let index_html = dir_entry
+                    .get_file("index.html")
+                    .expect("index.html should exist in the dist directory")
+                    .contents_utf8()
+                    .unwrap();
+
+                return (
+                    StatusCode::OK,
+                    [(http::header::CONTENT_TYPE, "text/html")],
+                    index_html,
+                )
+                    .into_response();
+            }
+            DirEntry::File(file_entry) => {
+                let content = file_entry.contents_utf8().unwrap();
+                let content_type =
+                    // some naive content type detection
+                    match file_entry.path().extension().and_then(|ext| ext.to_str()) {
+                        Some("html") => "text/html",
+                        Some("css") => "text/css",
+                        Some("js") => "text/javascript",
+                        Some("ico") => "image/x-icon",
+                        _ => "text/plain",
+                    };
+
+                return (
+                    StatusCode::OK,
+                    [(http::header::CONTENT_TYPE, content_type)],
+                    content,
+                )
+                    .into_response();
+            }
+        };
+    };
+
+    (
+        StatusCode::OK,
+        [(http::header::CONTENT_TYPE, "text/html")],
+        STUDIO_DIST
+            .get_file("index.html")
+            .expect("index.html should exist in the dist directory")
+            .contents_utf8()
+            .unwrap(),
+    )
+        .into_response()
+}

--- a/fpx/src/api/studio.rs
+++ b/fpx/src/api/studio.rs
@@ -2,25 +2,28 @@ use axum::extract::Request;
 use axum::response::IntoResponse;
 use http::StatusCode;
 use include_dir::{include_dir, Dir, DirEntry, File};
+use tracing::trace;
 
 static STUDIO_DIST: Dir<'_> = include_dir!("$CARGO_MANIFEST_DIR/../frontend/dist");
 
 /// A simple handler that serves the frontend Studio from STUDIO_DIST.
 pub async fn default_handler(req: Request) -> impl IntoResponse {
+    trace!(uri=?req.uri(), "Serving file from embedded Studio");
+
     let path = req.uri().path().trim_start_matches('/');
 
     // Retrieve the File that according to the path. If it is a directory, see
-    // if there is an index.html file. Always fallback to the index.html in the
-    // root.
+    // if there is an index.html file. Otherwise, always fallback to the
+    // index.html in the root.
     let file: Option<&File> = STUDIO_DIST
         .get_entry(path)
         .and_then(|entry| match entry {
-            DirEntry::Dir(dir_entry) => dir_entry.get_file("index.html"),
+            DirEntry::Dir(dir_entry) => dir_entry.get_file(dir_entry.path().join("index.html")),
             DirEntry::File(file_entry) => Some(file_entry),
         })
         .or_else(|| STUDIO_DIST.get_file("index.html"));
 
-    // Just return 404 if no file was found.
+    // If nothing matches _at all_, then return a 404.
     let Some(file) = file else {
         return StatusCode::NOT_FOUND.into_response();
     };

--- a/fpx/src/api/studio.rs
+++ b/fpx/src/api/studio.rs
@@ -1,63 +1,44 @@
 use axum::extract::Request;
-use axum::response::{IntoResponse, Response};
+use axum::response::IntoResponse;
 use http::StatusCode;
-use include_dir::{include_dir, Dir, DirEntry};
+use include_dir::{include_dir, Dir, DirEntry, File};
 
 static STUDIO_DIST: Dir<'_> = include_dir!("$CARGO_MANIFEST_DIR/../frontend/dist");
 
-pub async fn default_handler(req: Request) -> Response {
-    // check if it is a file, if so return the file
-    // if it is a directory, return the index.html file
-    // otherwise _always_ fallback index.html
-
+/// A simple handler that serves the frontend Studio from STUDIO_DIST.
+pub async fn default_handler(req: Request) -> impl IntoResponse {
     let path = req.uri().path().trim_start_matches('/');
 
-    if let Some(entry) = STUDIO_DIST.get_entry(path) {
-        match entry {
-            DirEntry::Dir(dir_entry) => {
-                let index_html = dir_entry
-                    .get_file("index.html")
-                    .expect("index.html should exist in the dist directory")
-                    .contents_utf8()
-                    .unwrap();
+    // Retrieve the File that according to the path. If it is a directory, see
+    // if there is an index.html file. Always fallback to the index.html in the
+    // root.
+    let file: Option<&File> = STUDIO_DIST
+        .get_entry(path)
+        .and_then(|entry| match entry {
+            DirEntry::Dir(dir_entry) => dir_entry.get_file("index.html"),
+            DirEntry::File(file_entry) => Some(file_entry),
+        })
+        .or_else(|| STUDIO_DIST.get_file("index.html"));
 
-                return (
-                    StatusCode::OK,
-                    [(http::header::CONTENT_TYPE, "text/html")],
-                    index_html,
-                )
-                    .into_response();
-            }
-            DirEntry::File(file_entry) => {
-                let content = file_entry.contents_utf8().unwrap();
-                let content_type =
-                    // some naive content type detection
-                    match file_entry.path().extension().and_then(|ext| ext.to_str()) {
-                        Some("html") => "text/html",
-                        Some("css") => "text/css",
-                        Some("js") => "text/javascript",
-                        Some("ico") => "image/x-icon",
-                        _ => "text/plain",
-                    };
+    // Just return 404 if not file was found.
+    let Some(file) = file else {
+        return StatusCode::NOT_FOUND.into_response();
+    };
 
-                return (
-                    StatusCode::OK,
-                    [(http::header::CONTENT_TYPE, content_type)],
-                    content,
-                )
-                    .into_response();
-            }
-        };
+    let content = file.contents_utf8().unwrap();
+    // Naive content type detection
+    let content_type = match file.path().extension().and_then(|ext| ext.to_str()) {
+        Some("html") => "text/html",
+        Some("css") => "text/css",
+        Some("js") => "text/javascript",
+        Some("ico") => "image/x-icon",
+        _ => "text/plain",
     };
 
     (
         StatusCode::OK,
-        [(http::header::CONTENT_TYPE, "text/html")],
-        STUDIO_DIST
-            .get_file("index.html")
-            .expect("index.html should exist in the dist directory")
-            .contents_utf8()
-            .unwrap(),
+        [(http::header::CONTENT_TYPE, content_type)],
+        content,
     )
         .into_response()
 }

--- a/fpx/src/api/studio.rs
+++ b/fpx/src/api/studio.rs
@@ -20,12 +20,13 @@ pub async fn default_handler(req: Request) -> impl IntoResponse {
         })
         .or_else(|| STUDIO_DIST.get_file("index.html"));
 
-    // Just return 404 if not file was found.
+    // Just return 404 if no file was found.
     let Some(file) = file else {
         return StatusCode::NOT_FOUND.into_response();
     };
 
-    let content = file.contents_utf8().unwrap();
+    let content = file.contents();
+
     // Naive content type detection
     let content_type = match file.path().extension().and_then(|ext| ext.to_str()) {
         Some("html") => "text/html",

--- a/fpx/src/commands/dev.rs
+++ b/fpx/src/commands/dev.rs
@@ -45,7 +45,7 @@ pub async fn handle_command(args: Args) -> Result<()> {
     )
     .await?;
 
-    let app = api::create_api(args.base_url.clone(), events, store, inspector_service).await;
+    let app = api::create_api(args.base_url.clone(), events, store, inspector_service);
 
     let listener = tokio::net::TcpListener::bind(&args.listen_address)
         .await


### PR DESCRIPTION
This currently requires a feature flag to actually embed the Studio. If this is enabled, then it _requires_ that the studio is build. To make it easier to work with fpx, I have made this an optin, for mostly the CI build. 

Resolves: FP-3793