### PR TITLE
Add status badge (2xx/4xx/5xx)

### DIFF
--- a/frontend/src/components/ui/status.tsx
+++ b/frontend/src/components/ui/status.tsx
@@ -1,0 +1,24 @@
+import { Badge } from "@/components/ui/badge";
+import clsx from "clsx";
+
+export function Status({ statusCode: statusCode }: { statusCode: number }) {
+  return (
+    <Badge
+      variant="secondary"
+      className={clsx(
+        "rounded",
+        {
+          "bg-green-950 text-green-300": statusCode / 100 === 2,
+        },
+        {
+          "bg-yellow-950 text-yellow-300": statusCode / 100 === 4,
+        },
+        {
+          "bg-red-950 text-red-300": statusCode / 100 === 5,
+        },
+      )}
+    >
+      {statusCode}
+    </Badge>
+  );
+}


### PR DESCRIPTION
Extracted from a different branch so that this could be reused more quickly in other parts of the codebase.

A simple status component with logic to show the right color for 2xx, 4xx, 5xx status codes.
